### PR TITLE
Activelettersort

### DIFF
--- a/app/Controller/LettersController.php
+++ b/app/Controller/LettersController.php
@@ -2,14 +2,7 @@
 App::uses('DboSource', 'Model/DataSource');
 
 class LettersController extends AppController {
-	public $components = array('RequestHandler');
-// new stuff
-	public $paginate = [
-        'limit' => 30,
-        'order' => ['Letter.date_received' => 'asc' ]
-          
-        
-    ];
+	public $components = array('RequestHandler', 'Paginator');
 
     public function initialize()
     {
@@ -26,47 +19,30 @@ class LettersController extends AppController {
 
 /**
  * ACTIVE LETTERS AND STAMPS
- * Creates a list of active letter and stamp requests.
+ * Creates a list of active letter and stamp requests. Uses Paginator
+ * to sort column headers. Paginator always must have a limit in the
+ * number of results, so the active function looks up the number of 
+ * records first.
  */ 
-	public function active($options = null)
+	public function active()
 	{
-		// checks if user is filtering by stamp or letter (type is set as options variable)
-		if (!$options) {
-			// finds all letters where letter is active, order by target date
-			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));			
-			// enables sortable column headers
-			//$this->set('filter_added', false);
-			$table =  ( isset($_GET['t']) ? $_GET['t'] : 'Letter' );
-			$sort = ( isset($_GET['s']) ? $_GET['s'] : 'date_received' );
-			$order = ( isset($_GET['o']) ? $_GET['o'] : 'asc' );
-			
-			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order"))));
-			$letters = $this->paginate('Letter');
-			$this->set(compact('letters'));
-			//$isAsc = isset($_GET['order'])? (bool) $_GET['order']: 1;
-			//old version 
-			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order"))));
-			//$this->paginate = $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order")));
-			//$letters = $this->paginate();
-			//$this->set(compact('letters'));
-
-			//if ($isAsc) {
-			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("$table.$sort" => "$order"))));
-			//} else {
-			//	$order = 'desc';
-			//	$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("$table.$sort" => "$order"))));
-			//}
-		//}
-			//$this->set('letters', $this->paginate($table));
-			//new stuff
-		//else {
-			// finds all letters where letter is active AND type matches filter, orders by target date
-			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.type' => $options, 'Letter.active' => true), 'order' => array('Letter.target_date'))));
-			// disables sortable column headers
-			//$this->set('filter_added', true);
-			//$this->set('filter', $options);
-		//}
-	} }
+		// Look up number of active letter requests
+		$limit = $this->Letter->find('count', array('conditions' => array('Letter.active' => true)));
+		
+		// Use paginator to allow sorting of column headers
+		$this->Paginator->settings = array(
+			// Use GET paramaters
+			'paramType' => 'querystring',
+			// Only retrieve active letter requests
+			'conditions' => array('Letter.active' => true),
+			'limit' => $limit,
+			// Order by date received by default
+			'order' => array('Letter.date_received' => 'asc')
+		);
+		$letters = $this->paginate('Letter');
+		// Pass in the results
+		$this->set(compact('letters'));
+	}
 /**
  * LETTER AND STAMP REQUEST HISTORY
  * Displays all of the letter and stamp requests that have ever been created.

--- a/app/Controller/LettersController.php
+++ b/app/Controller/LettersController.php
@@ -3,12 +3,27 @@ App::uses('DboSource', 'Model/DataSource');
 
 class LettersController extends AppController {
 	public $components = array('RequestHandler');
+// new stuff
+	public $paginate = [
+        'limit' => 30,
+        'order' => ['Letter.date_received' => 'asc' ]
+          
+        
+    ];
+
+    public function initialize()
+    {
+        parent::initialize();
+        $this->loadComponent('Paginator');
+    } 
 	
 	public function beforeFilter()
 	{
 		parent::beforeFilter();
 		$this->Auth->allow('lettersDueToday');
 	}
+
+
 /**
  * ACTIVE LETTERS AND STAMPS
  * Creates a list of active letter and stamp requests.
@@ -18,17 +33,40 @@ class LettersController extends AppController {
 		// checks if user is filtering by stamp or letter (type is set as options variable)
 		if (!$options) {
 			// finds all letters where letter is active, order by target date
-			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));			
+			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active' => true), 'order' => 'Letter.target_date')));			
 			// enables sortable column headers
-			$this->set('filter_added', false);
-		} else {
+			//$this->set('filter_added', false);
+			$table =  ( isset($_GET['t']) ? $_GET['t'] : 'Letter' );
+			$sort = ( isset($_GET['s']) ? $_GET['s'] : 'date_received' );
+			$order = ( isset($_GET['o']) ? $_GET['o'] : 'asc' );
+			
+			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order"))));
+			$letters = $this->paginate('Letter');
+			$this->set(compact('letters'));
+			//$isAsc = isset($_GET['order'])? (bool) $_GET['order']: 1;
+			//old version 
+			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order"))));
+			//$this->paginate = $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("Letter.$sort" => "$order")));
+			//$letters = $this->paginate();
+			//$this->set(compact('letters'));
+
+			//if ($isAsc) {
+			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("$table.$sort" => "$order"))));
+			//} else {
+			//	$order = 'desc';
+			//	$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.active'), 'order' => array("$table.$sort" => "$order"))));
+			//}
+		//}
+			//$this->set('letters', $this->paginate($table));
+			//new stuff
+		//else {
 			// finds all letters where letter is active AND type matches filter, orders by target date
-			$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.type' => $options, 'Letter.active' => true), 'order' => array('Letter.target_date'))));
+			//$this->set('letters', $this->Letter->find('all', array('conditions' => array('Letter.type' => $options, 'Letter.active' => true), 'order' => array('Letter.target_date'))));
 			// disables sortable column headers
-			$this->set('filter_added', true);
-			$this->set('filter', $options);
-		}
-	}
+			//$this->set('filter_added', true);
+			//$this->set('filter', $options);
+		//}
+	} }
 /**
  * LETTER AND STAMP REQUEST HISTORY
  * Displays all of the letter and stamp requests that have ever been created.

--- a/app/View/Letters/active.ctp
+++ b/app/View/Letters/active.ctp
@@ -6,19 +6,22 @@ $(document).ready(function(){
 
 <h2 class="title">Letter and Stamp Request Queue</h1>
 
-<p></span>&nbsp;</p>
+<p>&nbsp;</p>
 
 <div class="col-sm-9 col-sm-offset-1">
+	
+
 	<table class="table table-striped">
 		<tr>
-			<th>Date Received</th>
-			<th>Target Date</th>
-			<th>Member</th>
-			<th>Type</th>
+		
+			<th><?php echo $this->Paginator->sort('date_received', 'Date Received', array('class' => 'button')); ?></th>
+			<th><?php echo $this->Paginator->sort('target_date', 'Target Date', array('class' => 'button')); ?></th>
+			<th><?php echo $this->Paginator->sort('Member.short_name', 'Member', array('class' => 'button')); ?></th>
+			<th><?php echo $this->Paginator->sort('type', 'Type', array('class' => 'button')); ?></th>
 			<th>New</th>
 			<th>Revised</th>
-			<th>Enrollment</th>
-			<th>Owner</th>
+			<th><?php echo $this->Paginator->sort('enrollment', 'Enrollment', array('class' => 'button')); ?></th>
+			<th><?php echo $this->Paginator->sort('User.first_name', 'Owner', array('class' => 'button')); ?></th>
 			<th colspan="3">Actions</th>
 		</tr>
 		
@@ -26,7 +29,7 @@ $(document).ready(function(){
 			$total_new = 0;
 			$total_revised = 0;
 			$total_enrollment = 0;
-		?>
+		?>	
 		
 		<?php if ($letters == null) { ?>
 		<tr><td colspan="3">No active letters</td></tr>
@@ -64,5 +67,7 @@ $(document).ready(function(){
 	<p>New Letters: <?php echo $total_new . ' (' . $total_enrollment; ?> enrollment)</p>
 	<p>Revised Letters: <?php echo $total_revised; ?></p>
 	
+
+
 </div>
 <p>&nbsp;</p>

--- a/app/View/Letters/active.ctp
+++ b/app/View/Letters/active.ctp
@@ -13,7 +13,6 @@ $(document).ready(function(){
 
 	<table class="table table-striped">
 		<tr>
-		
 			<th><?php echo $this->Paginator->sort('date_received', 'Date Received', array('class' => 'button')); ?></th>
 			<th><?php echo $this->Paginator->sort('target_date', 'Target Date', array('class' => 'button')); ?></th>
 			<th><?php echo $this->Paginator->sort('Member.short_name', 'Member', array('class' => 'button')); ?></th>
@@ -34,8 +33,7 @@ $(document).ready(function(){
 		<?php if ($letters == null) { ?>
 		<tr><td colspan="3">No active letters</td></tr>
 		<?php } else {
-			
-			
+
 			foreach ($letters as $letter): ?>
 		<tr>
 			<td><?php echo $letter['Letter']['date_received']; ?></td>
@@ -51,16 +49,11 @@ $(document).ready(function(){
 			<td><?php echo $this->Form->postLink("<span class='glyphicon glyphicon-remove action-image' aria-hidden='true'></span>", array('controller' => 'letters', 'action' => 'delete', $letter['Letter']['id']), array('escapeTitle' => false, 'confirm' => 'Are you sure you want to delete this letter or stamp request? If needed, you can edit it by clicking the View icon.')); ?></td>
 		</tr>
 		<?php
-			$total_new += $letter['Letter']['new_templates'];
-			$total_revised += $letter['Letter']['revised_templates'];
-			$total_enrollment += ($letter['Letter']['enrollment'] ? $letter['Letter']['new_templates'] : 0);
-		?>	
-		
-		
-		
-		
-		<?php endforeach; ?>
-		<?php unset($letter); 
+				$total_new += $letter['Letter']['new_templates'];
+				$total_revised += $letter['Letter']['revised_templates'];
+				$total_enrollment += ($letter['Letter']['enrollment'] ? $letter['Letter']['new_templates'] : 0);
+			endforeach;
+			unset($letter); 
 		} ?>
 	</table>
 	<p>Total Letter Requests:</p>


### PR DESCRIPTION
Previously, the active letters queue would only display records in the order in which they were due. You can now also sort the queue by any other field in the active letters queue. For example, if you want to sort by Owner, you can do so by clicking on the header link in the "Owner" column.